### PR TITLE
[JENKINS-68461] Prepare DTKit 2 API for removal of JAXB and Java 11 requirement

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 // see https://github.com/jenkins-infra/pipeline-library
-buildPlugin(jenkinsVersions: [null, '2.102'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <java.level>8</java.level>
         <dtkit-frmk.version>3.0.0</dtkit-frmk.version>
-        <jenkins.version>2.263.1</jenkins.version>
+        <jenkins.version>2.204.6</jenkins.version>
     </properties>
 
     <repositories>
@@ -42,8 +42,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.263.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-2.204.x</artifactId>
+                <version>18</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>jaxb</artifactId>
-            <version>2.3.6-1</version>
+            <version>2.3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <java.level>8</java.level>
         <dtkit-frmk.version>3.0.0</dtkit-frmk.version>
-        <jenkins.version>2.204.6</jenkins.version>
+        <jenkins.version>2.263.1</jenkins.version>
     </properties>
 
     <repositories>
@@ -42,8 +42,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
-                <version>18</version>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>984.vb5eaac999a7e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -55,6 +55,11 @@
             <groupId>org.jenkins-ci.lib.dtkit</groupId>
             <artifactId>dtkit-metrics-model</artifactId>
             <version>${dtkit-frmk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jaxb</artifactId>
+            <version>2.3.6-1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
See [JENKINS-68461](https://issues.jenkins.io/browse/JENKINS-68461). This plugin consumes JAXB. But when running on Java 9+, JAXB is not included on the classpath by default. The only way for a plugin to have access to JAXB when running on Jenkins 2.164 or later on Java 11 is to declare a plugin-to-plugin dependency on JAXB API plugin (recommended) or to embed JAXB into its `.jpi` file. This PR does the former to ensure that DTKit 2 API always has access to JAXB on its classpath. CC @nfalco79 